### PR TITLE
try adding roc-ls support

### DIFF
--- a/nvim/lua/plugins/lspconfig.lua
+++ b/nvim/lua/plugins/lspconfig.lua
@@ -1,0 +1,12 @@
+return {
+  "neovim/nvim-lspconfig",
+  opts = {
+    servers = {
+      roc_ls = {
+        mason = false,
+        cmd = { "~/oss/roc/target/release/roc_ls" },
+        filetypes = { "roc" },
+      },
+    },
+  },
+}


### PR DESCRIPTION
Doesn't quite work yet:
```
1    Warn  15:39:16 notify.warn [lspconfig] Cannot access configuration for roc_ls. Ensure this server is listed in `server_configurations.md` or added as a custom server.
```

But after trying the server in vscode, it seems like it's still a work in progress. I'll check back in 2024