### PR TITLE
Add Ansible playbook for resizing VM disks and growing filesystems

### DIFF
--- a/homelab/justfile
+++ b/homelab/justfile
@@ -37,6 +37,9 @@ bootstrap +hosts:
 wireguard +hosts="all":
     ansible-playbook vms/wireguard.yaml --inventory ~/.files/homelab/inventory.yaml --limit "{{ hosts }}" --vault-password-file ~/.ansible-password
 
+resize-disk vm new_disk_size:
+    ansible-playbook vms/resize-disk.yaml --inventory ~/.files/homelab/inventory.yaml --extra-vars "target_vm={{ vm }} new_disk_size={{ new_disk_size }}"
+
 eject-cloud-init-io vm:
     virsh detach-disk {{ vm }} hda --live --config
     rm /var/lib/libvirt/images/{{ vm }}-cloud-init.iso

--- a/homelab/vms/resize-disk.yaml
+++ b/homelab/vms/resize-disk.yaml
@@ -1,0 +1,118 @@
+---
+# Resize a VM's disk image and grow the guest partition/filesystem to match.
+#
+# Usage:
+#   ansible-playbook resize-disk.yaml -e "target_vm=staging-db new_disk_size=50G"
+#
+# The new_disk_size can be an absolute size (e.g. "50G") or a relative increment (e.g. "+25G").
+#
+# Optional variables:
+#   partition_number  - partition to grow (default: 1)
+#   disk_device       - block device inside the guest (default: /dev/vda)
+
+- name: Resize VM Disk Image
+  hosts: localhost
+  vars:
+    libvirt_images: /var/lib/libvirt/images
+
+  tasks:
+    - name: Validate required variables
+      assert:
+        that:
+          - target_vm is defined
+          - new_disk_size is defined
+        fail_msg: "Usage: ansible-playbook resize-disk.yaml -e 'target_vm=<name> new_disk_size=<size>'"
+
+    - name: Check VM exists
+      virt:
+        name: "{{ target_vm }}"
+        command: status
+      register: vm_status
+
+    - name: Display current VM status
+      debug:
+        msg: "{{ target_vm }} is {{ vm_status.status }}"
+
+    - name: Get current disk size
+      command: qemu-img info --output=json {{ libvirt_images }}/{{ target_vm }}.qcow2
+      register: disk_info
+      changed_when: false
+
+    - name: Display current disk size
+      debug:
+        msg: "Current virtual size: {{ (disk_info.stdout | from_json)['virtual-size'] | int // (1024*1024*1024) }}G"
+
+    - name: Shut down VM gracefully
+      virt:
+        name: "{{ target_vm }}"
+        state: shutdown
+      when: vm_status.status == "running"
+
+    - name: Wait for VM to shut down
+      virt:
+        name: "{{ target_vm }}"
+        command: status
+      register: shutdown_status
+      until: shutdown_status.status == "shutdown"
+      retries: 30
+      delay: 5
+      when: vm_status.status == "running"
+
+    - name: Resize qcow2 disk image
+      command: qemu-img resize {{ libvirt_images }}/{{ target_vm }}.qcow2 {{ new_disk_size }}
+
+    - name: Verify new disk size
+      command: qemu-img info --output=json {{ libvirt_images }}/{{ target_vm }}.qcow2
+      register: new_disk_info
+      changed_when: false
+
+    - name: Display new disk size
+      debug:
+        msg: "New virtual size: {{ (new_disk_info.stdout | from_json)['virtual-size'] | int // (1024*1024*1024) }}G"
+
+    - name: Start VM
+      virt:
+        name: "{{ target_vm }}"
+        state: running
+
+    - name: Wait for VM to be accessible via SSH
+      wait_for:
+        host: "{{ hostvars[target_vm]['ansible_host'] }}"
+        port: 22
+        delay: 5
+        timeout: 120
+
+- name: Grow Partition and Filesystem
+  hosts: "{{ target_vm }}"
+  become: true
+  vars:
+    disk_device: /dev/vda
+    partition_number: 1
+
+  tasks:
+    - name: Install growpart
+      apt:
+        name: cloud-guest-utils
+        state: present
+
+    - name: Grow partition to fill available space
+      command: growpart {{ disk_device }} {{ partition_number }}
+      register: growpart_result
+      changed_when: "'CHANGED' in growpart_result.stdout"
+      failed_when:
+        - growpart_result.rc != 0
+        - "'NOCHANGE' not in growpart_result.stdout"
+
+    - name: Resize filesystem
+      command: resize2fs {{ disk_device }}{{ partition_number }}
+      register: resize_result
+      changed_when: resize_result.rc == 0
+
+    - name: Display new filesystem size
+      command: df -h /
+      register: df_output
+      changed_when: false
+
+    - name: Show result
+      debug:
+        msg: "{{ df_output.stdout_lines }}"

--- a/homelab/vms/resize-disk.yaml
+++ b/homelab/vms/resize-disk.yaml
@@ -2,7 +2,7 @@
 # Resize a VM's disk image and grow the guest partition/filesystem to match.
 #
 # Usage:
-#   ansible-playbook resize-disk.yaml -e "target_vm=staging-db new_disk_size=50G"
+#   ansible-playbook -i ../inventory.yaml resize-disk.yaml -e "target_vm=staging-db new_disk_size=50G"
 #
 # The new_disk_size can be an absolute size (e.g. "50G") or a relative increment (e.g. "+25G").
 #
@@ -21,7 +21,10 @@
         that:
           - target_vm is defined
           - new_disk_size is defined
-        fail_msg: "Usage: ansible-playbook resize-disk.yaml -e 'target_vm=<name> new_disk_size=<size>'"
+          - target_vm in hostvars
+        fail_msg: >-
+          Usage: ansible-playbook -i ../inventory.yaml resize-disk.yaml -e 'target_vm=<name> new_disk_size=<size>'
+          (make sure to pass the inventory file with -i)
 
     - name: Check VM exists
       virt:

--- a/homelab/vms/resize-disk.yaml
+++ b/homelab/vms/resize-disk.yaml
@@ -34,7 +34,7 @@
         msg: "{{ target_vm }} is {{ vm_status.status }}"
 
     - name: Get current disk size
-      command: qemu-img info --output=json {{ libvirt_images }}/{{ target_vm }}.qcow2
+      command: qemu-img info -U --output=json {{ libvirt_images }}/{{ target_vm }}.qcow2
       register: disk_info
       changed_when: false
 


### PR DESCRIPTION
## Summary
This PR adds a new Ansible playbook that automates the process of resizing QCOW2 disk images for libvirt-managed VMs and growing the guest partition/filesystem to match the new size.

## Changes
- **New file**: `homelab/vms/resize-disk.yaml` - A two-play Ansible playbook that:
  - Validates required variables (`target_vm` and `new_disk_size`)
  - Checks VM status and gracefully shuts down the VM if running
  - Resizes the QCOW2 disk image using `qemu-img resize`
  - Verifies the resize operation with before/after disk size reporting
  - Restarts the VM and waits for SSH connectivity
  - Grows the guest partition using `growpart` (from cloud-guest-utils)
  - Resizes the filesystem using `resize2fs`
  - Reports the final filesystem size

## Implementation Details
- Supports both absolute sizes (e.g., "50G") and relative increments (e.g., "+25G") for `new_disk_size`
- Includes optional variables for `partition_number` (default: 1) and `disk_device` (default: /dev/vda)
- Implements proper error handling with conditional task execution and graceful failure modes
- Provides detailed debug output at each step for visibility into the resize process
- Waits up to 2 minutes for VM SSH connectivity before attempting filesystem operations
- Handles the case where `growpart` reports "NOCHANGE" (partition already at max size)

## Usage
```bash
ansible-playbook resize-disk.yaml -e "target_vm=staging-db new_disk_size=50G"
```

https://claude.ai/code/session_0183nsaq9jpcyr9TzoEzyCQS