### PR TITLE
Add image build redesign plan and fix cloud-init user handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 **/.DS_Store
 
+**/__pycache__/
+
 .vscode
 
 homelab/services/*/.env
@@ -15,5 +17,4 @@ homelab/services/timescaledb/timescaledb-data/
 homelab/services/timescaledb/postgres-data/
 homelab/services/timescaledb/pgadmin-data/
 homelab/services/traggo/.traggodata
-
 

--- a/homelab/LOGGING_SETUP.md
+++ b/homelab/LOGGING_SETUP.md
@@ -1,0 +1,92 @@
+# Logging Configuration
+
+## Overview
+
+This homelab uses Fluent Bit to collect logs from nerdctl containers and system audit logs, then ships them to Loki for centralized logging.
+
+## Configuration
+
+### Inventory Variables
+
+Each host in the monitoring group should have:
+
+- `logging_endpoint_ip`: IP address of the Loki server (defaults to `10.0.0.2`)
+- `logging_endpoint_port`: Port for Loki (defaults to `3100`)
+
+Example:
+```yaml
+staging-web:
+  hosts:
+    staging-web:
+      ansible_host: 10.0.0.31
+      ansible_user: deployer
+      logging_endpoint_ip: 10.0.0.2
+```
+
+### Log Sources
+
+#### 1. Container Logs (nerdctl)
+
+**Location**: `~/.local/share/nerdctl/*/containers/default/*/*-json.log`
+
+**Container name resolution**:
+- Checks symlinks in `~/.local/share/nerdctl/*/default/` directory
+- Falls back to reading the `hostname` file in the container directory
+- Example containers: `caddy`, `auth-service-server`, `dial-in-server`, etc.
+
+**Loki Labels**:
+- `job=container`
+- `host` - hostname from inventory
+- `container_name` - resolved container name
+- `container_id` - short (12 char) container ID
+- `user` - the user running the container
+
+#### 2. Audit Logs (laurel)
+
+**Location**: `/var/log/laurel/audit.log`
+
+**Loki Labels**:
+- `job=audit`
+- `host` - hostname from inventory
+- `action` - extracted audit action
+
+## Deployment
+
+Run the setup playbook to deploy monitoring configuration:
+
+```bash
+cd /home/steven/.files/homelab
+ansible-playbook -i inventory.yaml vms/set-up.yaml --limit monitoring
+```
+
+Or target specific hosts:
+
+```bash
+ansible-playbook -i inventory.yaml vms/set-up.yaml --limit staging-web
+```
+
+## Architecture
+
+```
+nerdctl containers → JSON logs → Fluent Bit → Loki
+                                     ↓
+                                 Lua script
+                               (name resolution)
+```
+
+## Files
+
+- `vms/tasks/monitoring.yaml` - Ansible tasks for installing and configuring Fluent Bit
+- `vms/templates/system-logs.yaml.j2` - Fluent Bit pipeline configuration
+- `vms/templates/process-container-logs.lua` - Lua script for container name resolution
+- `vms/templates/parsers.yaml.j2` - Log parsers (Docker JSON format, audit logs)
+- `vms/templates/fluent-bit.yaml.j2` - Main Fluent Bit configuration
+
+## Multi-Environment Support
+
+The configuration supports different logging endpoints per environment:
+
+- **Local homelab** hosts (`10.0.0.x`): Use `logging_endpoint_ip: 10.0.0.2`
+- **Cloud hosts** (`*.streetfortress.cloud`): Use `logging_endpoint_ip: logging.streetfortress.cloud`
+
+This allows each environment to have its own centralized logging infrastructure.

--- a/homelab/README.md
+++ b/homelab/README.md
@@ -7,3 +7,94 @@ You could be sleeping on using LLMs to help generate your IAC. A lot of the ansi
 
 ![Network Map](https://i.imgur.com/GnhIBC1.png)
 ![Grafana View](https://i.imgur.com/rAeIgVx.png)
+
+## Structure
+
+```
+homelab/
+  inventory.yaml                  # Ansible inventory -- all hosts, groups, hostvars
+  justfile                        # Recipes: create, delete, set-up, deploy, update
+  requirements.yaml               # Ansible Galaxy dependencies
+
+  images/                         # Image building (user-agnostic base images)
+    build.py                      # Orchestrator: VM lifecycle + ansible invocation
+    build-playbook.yaml           # apt upgrade, install spec packages, cleanup, convert
+    specs/                        # Declarative image profiles (vars files)
+      base.yaml                   #   minimal apt packages
+      containerd.yaml             #   base + container runtime prerequisites
+      nvidia.yaml                 #   base + GPU driver prerequisites
+      full.yaml                   #   everything
+
+  roles/                          # Ansible roles (planned)
+    dev_env/                      #   dotfiles, zsh, tmux, fzf, go, neovim, rust
+    containerd/                   #   nerdctl, rootless setup, apparmor, sysctl
+    nvidia/                       #   drivers, container toolkit, gpu exporter
+    monitoring/                   #   node_exporter, fluent-bit, laurel
+
+  vms/                            # VM lifecycle and deployment
+    create-linux.yaml             #   cloud-init + libvirt domain creation
+    create-windows.yaml           #   windows VM creation
+    deploy.yaml                   #   post-boot provisioning (planned, replaces set-up.yaml)
+    delete.yaml                   #   destroy + undefine + disk cleanup
+    update.yaml                   #   apt upgrade + reboot if needed
+    wireguard.yaml                #   WireGuard VPN configuration
+    tasks/
+      cloud-init.yaml             #   metadata, network-config, userdata → ISO
+      users.yaml                  #   user creation, SSH keys, sudoers
+      common.yaml                 #   dev tools + dotfiles (being split into roles)
+      containerd.yaml             #   rootless containers (being split into roles)
+      nvidia.yaml                 #   GPU drivers + toolkit
+      monitoring.yaml             #   node_exporter, fluent-bit, laurel
+      passwords.yaml              #   generate + vault-encrypt user passwords
+    templates/
+      userdata.yaml.j2            #   cloud-init user-data
+      metadata.yaml.j2            #   cloud-init instance metadata
+      network-config.yaml.j2      #   netplan static IP config
+      linux-definition.xml.j2     #   libvirt domain XML
+      fluent-bit/                 #   log pipeline configs
+
+  sandboxes/                      # Ephemeral architecture scenarios (planned)
+    architectures/                #   topology definitions (web-db, queue-worker, etc.)
+    containers/                   #   nerdctl compose files per role
+    tests/                        #   k6 load test scenarios
+
+  services/                       # Containerized services (nerdctl compose)
+    caddy/                        #   reverse proxy, DNS, TLS
+    monitoring/                   #   prometheus, loki, grafana, alertmanager
+    postgres/                     #   PostgreSQL + pgAdmin
+    timescaledb/                  #   TimescaleDB + pgAdmin
+    woodpecker/                   #   CI/CD pipeline
+    ollama-chat/                  #   LLM inference
+    penpot/                       #   design collaboration
+    dolibarr/                     #   ERP
+    homebridge/                   #   HomeKit bridge
+    traggo/                       #   time tracking
+    wordpress/                    #   CMS
+```
+
+## Workflow
+
+**Build a base image:**
+```
+./homelab/images/build.py --name base-24.04 --spec base
+```
+
+**Create a VM from that image:**
+```
+just create-linux devbox
+```
+
+**Deploy configuration (post-boot):**
+```
+just set-up devbox
+```
+
+## Design
+
+Images are user-agnostic system artifacts. Cloud-init handles identity
+(user, hostname, network, SSH keys). Post-boot provisioning applies
+environment configuration via Ansible roles.
+
+The deployment path is being refactored from flat task files into Ansible
+roles so the same building blocks serve both long-lived dev VMs and
+ephemeral sandbox scenarios. See `images/PLAN.md` for details.

--- a/homelab/images/PLAN.md
+++ b/homelab/images/PLAN.md
@@ -1,0 +1,120 @@
+# Custom VM Image Build Pipeline -- Redesign Plan
+
+## Problem
+
+The current `homelab/vms/` playbooks conflate image building and VM deployment
+through shared playbooks, tagged plays, and inconsistent user management. The
+build flow creates users that shouldn't exist in the final image, then tries to
+clean them up in a finalize step. This has led to lingering users with sudo
+access being baked into base images.
+
+## Design Principle
+
+**Images are user-agnostic.** The build creates a system-level artifact. Users,
+SSH keys, hostnames, and IPs are deployment concerns applied after boot.
+
+## Target Directory Structure
+
+```
+homelab/
+  images/                              # image building (this directory)
+    PLAN.md                            # this file
+    build.py                           # orchestrator (libvirt lifecycle + ansible invocation)
+    build-playbook.yaml                # single-purpose build playbook
+    versions.yaml                      # single source of truth for all version pins + checksums
+    specs/                             # declarative image profiles (vars files)
+      base.yaml                        # common packages, tools
+      containerd.yaml                  # rootless container system prerequisites
+      nvidia.yaml                      # GPU drivers + toolkit
+      full.yaml                        # everything
+    tasks/
+      packages.yaml                    # system-level apt installs
+      tools.yaml                       # go, rust, neovim, fzf (installed to /usr/local)
+      containerd-system.yaml           # uidmap, sysctl, apparmor profiles (no per-user setup)
+      nvidia.yaml                      # drivers, container toolkit, gpu exporter
+      harden.yaml                      # read-only root, fstab, delete builder user, cleanup
+  vms/                                 # VM lifecycle and deployment (existing, refactored)
+    create.yaml                        # libvirt domain creation (define, disk, start)
+    deploy.yaml                        # post-boot identity provisioning
+    tasks/
+      containerd-user.yaml             # containerd-rootless-setuptool.sh, per-user
+      dotfiles.yaml                    # zsh, tmux, nvim config, cloned into $HOME
+      monitoring.yaml                  # node_exporter, fluent-bit, laurel
+```
+
+## Implementation Steps
+
+### Phase 1: Centralize versions
+
+- [ ] Create `images/versions.yaml` with all version pins and SHA256 checksums
+- [ ] Add checksums to existing download tasks (`get_url` checksum param)
+- [ ] Reference `versions.yaml` as `vars_files` from existing playbooks
+
+### Phase 2: Dedicated build playbook
+
+- [ ] Create `images/build-playbook.yaml` with a single throwaway `builder` user
+  - Connects as `builder` (created by cloud-init for the build VM)
+  - Installs everything system-wide (no user home dependencies)
+  - Deletes `builder` user at the end -- no finalize gymnastics
+- [ ] Adapt `build-custom-image.py` → `images/build.py`
+  - Simplify: no `vm_username` passthrough, builder user is always `builder`
+  - Keep prerequisite checks, VM lifecycle management, arg parsing
+- [ ] Create image profile specs under `images/specs/`
+  - Each profile is a vars file that the build playbook loads
+  - Profiles compose (e.g., `full.yaml` includes containerd + nvidia + monitoring)
+
+### Phase 3: Split containerd tasks
+
+- [ ] Extract system-level container prerequisites into `images/tasks/containerd-system.yaml`
+  - uidmap package, `/etc/subuid` + `/etc/subgid` templates (parameterized by user)
+  - AppArmor profile for rootlesskit (parameterized path)
+  - sysctl settings (ping_group_range, unprivileged_port_start)
+- [ ] Extract per-user container setup into `vms/tasks/containerd-user.yaml`
+  - nerdctl extraction to `~/.local`
+  - `containerd-rootless-setuptool.sh install`
+  - `install-bypass4netnsd`
+  - `loginctl enable-linger`
+- [ ] System-level tasks run at image build time, user-level tasks run at deploy time
+
+### Phase 4: Read-only root filesystem
+
+- [ ] Create `images/tasks/harden.yaml` (runs last in build playbook)
+  - Configure tmpfs mounts in fstab for `/tmp`, `/var/tmp`, `/run`
+  - Mark root filesystem read-only in fstab (`defaults,ro`)
+  - Ensure `/var/lib` and `/home` are on separate mutable mounts
+  - Set up `tmpfiles.d` entries for volatile paths that services expect
+- [ ] Test with a deployed VM to verify:
+  - System boots cleanly with ro root
+  - Container volumes under `$HOME` are writable
+  - Logs, package state, and other mutable paths work correctly
+  - `apt` operations are blocked (or require remount -- this is intentional)
+
+### Phase 5: Refactor deployment path
+
+- [ ] Create `vms/deploy.yaml` for post-boot identity provisioning
+  - Cloud-init handles: user creation, hostname, IP, SSH key import
+  - deploy.yaml handles: dotfiles, rootless containerd init, monitoring, wireguard
+- [ ] Refactor `vms/tasks/dotfiles.yaml` out of `tasks/common.yaml`
+  - Clone .files repo, symlink zsh/tmux/nvim configs
+  - This is user-scoped, not image-scoped
+- [ ] Retire `custom-base-image.yaml` and its tagged multi-play approach
+
+### Phase 6: Cleanup
+
+- [ ] Remove `bootstrap-deployer.yaml` if deployer user is no longer needed
+  (deploy.yaml creates the correct user per-VM via cloud-init)
+- [ ] Consolidate inventory `ansible_user` to a single convention
+- [ ] Update `requirements.yaml` to declare all used roles (prometheus)
+- [ ] Delete dead code and unused templates
+
+## Notes
+
+- The Python orchestrator (`build.py`) is the right approach for managing the
+  build VM lifecycle. Packer would replace ~100 lines of this script but adds a
+  dependency for minimal gain.
+- `versions.yaml` enables automated version bump scripts (check GitHub releases,
+  update pins + checksums, open PR).
+- The read-only root pairs naturally with rootless nerdctl: all container state
+  lives under `$HOME` on a mutable filesystem, while the OS root is immutable.
+- dm-verity is a future option for tamper-evident roots but significantly more
+  complex. Start with fstab `ro` + mutable bind mounts.

--- a/homelab/images/PLAN.md
+++ b/homelab/images/PLAN.md
@@ -16,39 +16,149 @@ SSH keys, hostnames, and IPs are deployment concerns applied after boot.
 ## Target Directory Structure
 
 ```
+versions.yaml                            # single source of truth for ALL version pins + checksums
+                                         # consumed by both install.py and Ansible playbooks
 homelab/
-  images/                              # image building (this directory)
-    PLAN.md                            # this file
-    build.py                           # orchestrator (libvirt lifecycle + ansible invocation)
-    build-playbook.yaml                # single-purpose build playbook
-    versions.yaml                      # single source of truth for all version pins + checksums
-    specs/                             # declarative image profiles (vars files)
-      base.yaml                        # common packages, tools
-      containerd.yaml                  # rootless container system prerequisites
-      nvidia.yaml                      # GPU drivers + toolkit
-      full.yaml                        # everything
+  images/                                # image building (this directory)
+    PLAN.md                              # this file
+    build.py                             # orchestrator (libvirt lifecycle + ansible invocation)
+    build-playbook.yaml                  # single-purpose build playbook
+    specs/                               # declarative image profiles (vars files)
+      base.yaml                          # common packages, tools
+      containerd.yaml                    # rootless container system prerequisites
+      nvidia.yaml                        # GPU drivers + toolkit
+      full.yaml                          # everything
     tasks/
-      packages.yaml                    # system-level apt installs
-      tools.yaml                       # go, rust, neovim, fzf (installed to /usr/local)
-      containerd-system.yaml           # uidmap, sysctl, apparmor profiles (no per-user setup)
-      nvidia.yaml                      # drivers, container toolkit, gpu exporter
-      harden.yaml                      # read-only root, fstab, delete builder user, cleanup
-  vms/                                 # VM lifecycle and deployment (existing, refactored)
-    create.yaml                        # libvirt domain creation (define, disk, start)
-    deploy.yaml                        # post-boot identity provisioning
+      packages.yaml                      # system-level apt installs
+      tools.yaml                         # go, rust, neovim, fzf (installed to /usr/local)
+      containerd-system.yaml             # uidmap, sysctl, apparmor profiles (no per-user setup)
+      nvidia.yaml                        # drivers, container toolkit, gpu exporter
+      harden.yaml                        # read-only root, fstab, delete builder user, cleanup
+  vms/                                   # VM lifecycle and deployment (existing, refactored)
+    create.yaml                          # libvirt domain creation (define, disk, start)
+    deploy.yaml                          # post-boot identity provisioning
     tasks/
-      containerd-user.yaml             # containerd-rootless-setuptool.sh, per-user
-      dotfiles.yaml                    # zsh, tmux, nvim config, cloned into $HOME
-      monitoring.yaml                  # node_exporter, fluent-bit, laurel
+      containerd-user.yaml               # containerd-rootless-setuptool.sh, per-user
+      dotfiles.yaml                      # zsh, tmux, nvim config, cloned into $HOME
+      monitoring.yaml                    # node_exporter, fluent-bit, laurel
+shell/
+  scripts/
+    install.py                           # reads versions.yaml, installs user-level CLI tools
 ```
 
 ## Implementation Steps
 
-### Phase 1: Centralize versions
+### Phase 1: Versions manifest and install.py redesign
 
-- [ ] Create `images/versions.yaml` with all version pins and SHA256 checksums
-- [ ] Add checksums to existing download tasks (`get_url` checksum param)
-- [ ] Reference `versions.yaml` as `vars_files` from existing playbooks
+Create a single `versions.yaml` at the repo root. Both `install.py` and Ansible
+playbooks read from it. No tool has its version defined in more than one place.
+
+#### versions.yaml format
+
+```yaml
+# Entries used by install.py for user-level CLI tools
+bat:
+  version: "0.25.0"
+  sha256: "..."
+  repo: sharkdp/bat                              # shorthand for GitHub releases URL
+  artifact: "bat-v{version}-{arch}-unknown-linux-musl.tar.gz"
+  binary: "bat-v{version}-{arch}-unknown-linux-musl/bat"
+  arch: x86_64
+
+jq:
+  version: "1.7.1"
+  sha256: "..."
+  repo: jqlang/jq
+  artifact: "jq-linux-{arch}"                    # not a tarball, just a raw binary
+  binary: "jq-linux-{arch}"
+  arch: amd64
+
+nerdctl:
+  version: "2.1.3"
+  sha256: "..."
+  repo: containerd/nerdctl
+  artifact: "nerdctl-full-{version}-linux-{arch}.tar.gz"
+  extract_to: "~/.local"                         # whole tree, not a single binary
+  arch: amd64
+
+# Entries used only by Ansible (system-level installs)
+go:
+  version: "1.24.2"
+  sha256: "..."
+  url: "https://golang.org/dl/go{version}.linux-amd64.tar.gz"
+  system: true                                   # installed to /usr/local by Ansible
+
+neovim:
+  version: "0.11.3"
+  sha256: "..."
+  repo: neovim/neovim
+  artifact: "nvim-linux-x86_64.tar.gz"
+  system: true
+
+nvidia_gpu_exporter:
+  version: "1.3.2"
+  sha256: "..."
+  repo: utkuozdemir/nvidia_gpu_exporter
+  artifact: "nvidia_gpu_exporter_{version}_linux_x86_64.tar.gz"
+  system: true
+```
+
+Most tools follow one of three installation patterns:
+
+1. **Binary in a subdirectory** -- `binary` field points to path inside archive
+   (bat, dust, fd, rg, uv, step, etc.)
+2. **Binary at archive root** -- `binary` matches the filename
+   (eza, just, starship, zoxide, duf, etc.)
+3. **Whole tree extraction** -- `extract_to` instead of `binary`
+   (nerdctl only)
+
+Raw binaries (not tarballs) like jq are detected by artifact extension.
+
+#### install.py redesign
+
+The `PROGRAMS` dict and all embedded `setup_script` bash strings are replaced by
+reading `versions.yaml`. The installer becomes ~50 lines of logic:
+
+```python
+def install(name, spec):
+    url = build_url(spec)                        # from repo + artifact, or explicit url
+    with tempfile.TemporaryDirectory() as tmp:
+        path = download(url, tmp)
+        verify_checksum(path, spec["sha256"])
+        if is_archive(path):
+            extract(path, tmp)
+        if "extract_to" in spec:
+            dest = os.path.expanduser(spec["extract_to"])
+            extract(path, dest)                  # nerdctl-style: whole tree
+        else:
+            binary = spec["binary"].format(version=spec["version"], arch=arch)
+            shutil.move(os.path.join(tmp, binary), os.path.join(INSTALL_DIR, name))
+            os.chmod(os.path.join(INSTALL_DIR, name), 0o755)
+```
+
+install.py filters for entries where `system` is not true (or absent). Ansible
+loads the full file and references `{{ versions.go.version }}`.
+
+#### Migration steps
+
+- [ ] Create `versions.yaml` at repo root with all current version pins + SHA256
+      checksums, consolidated from:
+  - `shell/scripts/install.py` (20 tools)
+  - `homelab/vms/custom-base-image.yaml` (nerdctl, go, neovim, nvidia_gpu_exporter)
+  - `homelab/vms/tasks/common.yaml` (go, neovim -- duplicates)
+  - `homelab/vms/tasks/nvidia.yaml` (nvidia_gpu_exporter -- duplicate)
+  - `homelab/vms/set-up.yaml` (nerdctl, nvidia_gpu_exporter -- duplicates)
+  - `shell/bash/installs` (migrate any still-needed tools, then retire the file)
+- [ ] Rewrite `install.py` to read `versions.yaml`, drop embedded PROGRAMS dict
+  - Three install patterns, no per-tool bash scripts
+  - Verify SHA256 after download
+  - Keep `AUTOMATIC` mode and `is_installed()` skip logic
+- [ ] Update Ansible playbooks to use `vars_files: [../../versions.yaml]`
+  - Replace inline `nerdctl_version`, `go_version`, `nvim_version`, etc.
+  - Add `checksum: "sha256:{{ versions.<tool>.sha256 }}"` to `get_url` tasks
+- [ ] Retire `shell/bash/installs` (migrate tmux, shellcheck, vivid if still used)
+- [ ] (Optional) Write a version bump script that checks GitHub releases API,
+      updates version + checksum in `versions.yaml`, and opens a PR
 
 ### Phase 2: Dedicated build playbook
 
@@ -107,14 +217,32 @@ homelab/
 - [ ] Update `requirements.yaml` to declare all used roles (prometheus)
 - [ ] Delete dead code and unused templates
 
+## Current Version Sprawl (for reference)
+
+Tools with versions defined in multiple places (at time of writing):
+
+| Tool                 | install.py | custom-base-image.yaml | common.yaml | set-up.yaml | tasks/nvidia.yaml | bash/installs |
+|----------------------|-----------|------------------------|-------------|-------------|-------------------|---------------|
+| nerdctl              | 2.0.3     | 2.1.3                  | --          | 2.1.3       | --                | --            |
+| go                   | --        | 1.24.2                 | 1.24.2      | --          | --                | 1.19.4        |
+| neovim               | --        | 0.11.3                 | 0.11.3      | --          | --                | 0.10.4        |
+| nvidia_gpu_exporter  | --        | 1.3.2                  | --          | 1.3.2       | 1.3.2             | --            |
+
+`shell/bash/installs` also has stale pins for clusterctl, glow, helm, k9s, kind,
+kubectx, node.js, python, shellcheck, tmux, vivid -- most from a previous k8s era.
+
 ## Notes
 
 - The Python orchestrator (`build.py`) is the right approach for managing the
   build VM lifecycle. Packer would replace ~100 lines of this script but adds a
   dependency for minimal gain.
-- `versions.yaml` enables automated version bump scripts (check GitHub releases,
-  update pins + checksums, open PR).
+- `versions.yaml` at the repo root is the single source of truth for all binary
+  versions. install.py consumes it for user-level CLI tools, Ansible consumes it
+  for system-level installs. No version is defined in more than one place.
 - The read-only root pairs naturally with rootless nerdctl: all container state
   lives under `$HOME` on a mutable filesystem, while the OS root is immutable.
 - dm-verity is a future option for tamper-evident roots but significantly more
   complex. Start with fstab `ro` + mutable bind mounts.
+- Container image versions (compose files under `homelab/services/`) are out of
+  scope for `versions.yaml` -- those are pinned per-service and don't overlap
+  with the CLI/system tool versions.

--- a/homelab/images/PLAN.md
+++ b/homelab/images/PLAN.md
@@ -51,21 +51,23 @@ Each image spec is a self-contained vars file that pins its own versions and
 package lists. Duplication across specs is acceptable -- keeping specs
 independent and readable is more valuable than DRY at this stage.
 
-- [ ] Create `images/build-playbook.yaml` with a single throwaway `builder` user
-  - Connects as `builder` (created by cloud-init for the build VM)
-  - Installs everything system-wide (no user home dependencies)q
+- [x] Create `images/build-playbook.yaml` with cloud-init default user
+  - Connects as `ubuntu` (cloud-init default -- simpler than creating a custom builder user)
+  - Installs everything system-wide via `become: true`
   - Loads a spec file via `--extra-vars "spec=base"` → `vars_files: [specs/{{ spec }}.yaml]`
-  - Deletes `builder` user at the end -- no finalize gymnastics
-- [ ] Adapt `build-custom-image.py` → `images/build.py`
-  - Simplify: no `vm_username` passthrough, builder user is always `builder`
+  - Deletes `ubuntu` user at the end -- no finalize gymnastics
+- [x] Adapt `build-custom-image.py` → `images/build.py`
+  - Simplify: no `vm_username` passthrough, cloud-init default user is always `ubuntu`
   - Accept `--spec` flag to select which image profile to build
   - Keep prerequisite checks, VM lifecycle management, arg parsing
-- [ ] Create image profile specs under `images/specs/`
-  - `base.yaml` -- apt packages, go, neovim, fzf, common CLI tools
-  - `containerd.yaml` -- base + nerdctl, uidmap, sysctl, apparmor for rootless containers
-  - `nvidia.yaml` -- base + GPU drivers, container toolkit, gpu exporter
-  - `full.yaml` -- containerd + nvidia + monitoring
+  - Validates spec file exists in `check_prerequisites()`
+- [x] Create image profile specs under `images/specs/`
+  - `base.yaml` -- minimal apt packages (curl, git, jq, make, tmux, etc.)
+  - `containerd.yaml` -- base + uidmap (stub, Phase 2 adds system tasks)
+  - `nvidia.yaml` -- base + ubuntu-drivers-common (stub, Phase 2 adds driver tasks)
+  - `full.yaml` -- containerd + nvidia packages (stub, Phase 2 adds all tasks)
   - Each spec owns its version pins (no shared versions manifest)
+- [x] Update inventory: custom-image-builder IP changed from 10.0.0.7 to 10.0.0.10
 
 ### Phase 2: Split containerd tasks
 

--- a/homelab/images/PLAN.md
+++ b/homelab/images/PLAN.md
@@ -16,8 +16,6 @@ SSH keys, hostnames, and IPs are deployment concerns applied after boot.
 ## Target Directory Structure
 
 ```
-versions.yaml                            # single source of truth for ALL version pins + checksums
-                                         # consumed by both install.py and Ansible playbooks
 homelab/
   images/                                # image building (this directory)
     PLAN.md                              # this file
@@ -33,7 +31,7 @@ homelab/
       tools.yaml                         # go, rust, neovim, fzf (installed to /usr/local)
       containerd-system.yaml             # uidmap, sysctl, apparmor profiles (no per-user setup)
       nvidia.yaml                        # drivers, container toolkit, gpu exporter
-      harden.yaml                        # read-only root, fstab, delete builder user, cleanup
+      cleanup.yaml                       # delete builder user, apt clean, truncate logs
   vms/                                   # VM lifecycle and deployment (existing, refactored)
     create.yaml                          # libvirt domain creation (define, disk, start)
     deploy.yaml                          # post-boot identity provisioning
@@ -41,139 +39,35 @@ homelab/
       containerd-user.yaml               # containerd-rootless-setuptool.sh, per-user
       dotfiles.yaml                      # zsh, tmux, nvim config, cloned into $HOME
       monitoring.yaml                    # node_exporter, fluent-bit, laurel
-shell/
-  scripts/
-    install.py                           # reads versions.yaml, installs user-level CLI tools
 ```
 
 ## Implementation Steps
 
-### Phase 1: Versions manifest and install.py redesign
+### Phase 1: Dedicated build playbook and image specs
 
-Create a single `versions.yaml` at the repo root. Both `install.py` and Ansible
-playbooks read from it. No tool has its version defined in more than one place.
+> Note: Previously, we used 10.0.0.7 as our custom image builder VM IP. That IP is now in use by another lab service. 10.0.0.10 is available
 
-#### versions.yaml format
-
-```yaml
-# Entries used by install.py for user-level CLI tools
-bat:
-  version: "0.25.0"
-  sha256: "..."
-  repo: sharkdp/bat                              # shorthand for GitHub releases URL
-  artifact: "bat-v{version}-{arch}-unknown-linux-musl.tar.gz"
-  binary: "bat-v{version}-{arch}-unknown-linux-musl/bat"
-  arch: x86_64
-
-jq:
-  version: "1.7.1"
-  sha256: "..."
-  repo: jqlang/jq
-  artifact: "jq-linux-{arch}"                    # not a tarball, just a raw binary
-  binary: "jq-linux-{arch}"
-  arch: amd64
-
-nerdctl:
-  version: "2.1.3"
-  sha256: "..."
-  repo: containerd/nerdctl
-  artifact: "nerdctl-full-{version}-linux-{arch}.tar.gz"
-  extract_to: "~/.local"                         # whole tree, not a single binary
-  arch: amd64
-
-# Entries used only by Ansible (system-level installs)
-go:
-  version: "1.24.2"
-  sha256: "..."
-  url: "https://golang.org/dl/go{version}.linux-amd64.tar.gz"
-  system: true                                   # installed to /usr/local by Ansible
-
-neovim:
-  version: "0.11.3"
-  sha256: "..."
-  repo: neovim/neovim
-  artifact: "nvim-linux-x86_64.tar.gz"
-  system: true
-
-nvidia_gpu_exporter:
-  version: "1.3.2"
-  sha256: "..."
-  repo: utkuozdemir/nvidia_gpu_exporter
-  artifact: "nvidia_gpu_exporter_{version}_linux_x86_64.tar.gz"
-  system: true
-```
-
-Most tools follow one of three installation patterns:
-
-1. **Binary in a subdirectory** -- `binary` field points to path inside archive
-   (bat, dust, fd, rg, uv, step, etc.)
-2. **Binary at archive root** -- `binary` matches the filename
-   (eza, just, starship, zoxide, duf, etc.)
-3. **Whole tree extraction** -- `extract_to` instead of `binary`
-   (nerdctl only)
-
-Raw binaries (not tarballs) like jq are detected by artifact extension.
-
-#### install.py redesign
-
-The `PROGRAMS` dict and all embedded `setup_script` bash strings are replaced by
-reading `versions.yaml`. The installer becomes ~50 lines of logic:
-
-```python
-def install(name, spec):
-    url = build_url(spec)                        # from repo + artifact, or explicit url
-    with tempfile.TemporaryDirectory() as tmp:
-        path = download(url, tmp)
-        verify_checksum(path, spec["sha256"])
-        if is_archive(path):
-            extract(path, tmp)
-        if "extract_to" in spec:
-            dest = os.path.expanduser(spec["extract_to"])
-            extract(path, dest)                  # nerdctl-style: whole tree
-        else:
-            binary = spec["binary"].format(version=spec["version"], arch=arch)
-            shutil.move(os.path.join(tmp, binary), os.path.join(INSTALL_DIR, name))
-            os.chmod(os.path.join(INSTALL_DIR, name), 0o755)
-```
-
-install.py filters for entries where `system` is not true (or absent). Ansible
-loads the full file and references `{{ versions.go.version }}`.
-
-#### Migration steps
-
-- [ ] Create `versions.yaml` at repo root with all current version pins + SHA256
-      checksums, consolidated from:
-  - `shell/scripts/install.py` (20 tools)
-  - `homelab/vms/custom-base-image.yaml` (nerdctl, go, neovim, nvidia_gpu_exporter)
-  - `homelab/vms/tasks/common.yaml` (go, neovim -- duplicates)
-  - `homelab/vms/tasks/nvidia.yaml` (nvidia_gpu_exporter -- duplicate)
-  - `homelab/vms/set-up.yaml` (nerdctl, nvidia_gpu_exporter -- duplicates)
-  - `shell/bash/installs` (migrate any still-needed tools, then retire the file)
-- [ ] Rewrite `install.py` to read `versions.yaml`, drop embedded PROGRAMS dict
-  - Three install patterns, no per-tool bash scripts
-  - Verify SHA256 after download
-  - Keep `AUTOMATIC` mode and `is_installed()` skip logic
-- [ ] Update Ansible playbooks to use `vars_files: [../../versions.yaml]`
-  - Replace inline `nerdctl_version`, `go_version`, `nvim_version`, etc.
-  - Add `checksum: "sha256:{{ versions.<tool>.sha256 }}"` to `get_url` tasks
-- [ ] Retire `shell/bash/installs` (migrate tmux, shellcheck, vivid if still used)
-- [ ] (Optional) Write a version bump script that checks GitHub releases API,
-      updates version + checksum in `versions.yaml`, and opens a PR
-
-### Phase 2: Dedicated build playbook
+Each image spec is a self-contained vars file that pins its own versions and
+package lists. Duplication across specs is acceptable -- keeping specs
+independent and readable is more valuable than DRY at this stage.
 
 - [ ] Create `images/build-playbook.yaml` with a single throwaway `builder` user
   - Connects as `builder` (created by cloud-init for the build VM)
-  - Installs everything system-wide (no user home dependencies)
+  - Installs everything system-wide (no user home dependencies)q
+  - Loads a spec file via `--extra-vars "spec=base"` → `vars_files: [specs/{{ spec }}.yaml]`
   - Deletes `builder` user at the end -- no finalize gymnastics
 - [ ] Adapt `build-custom-image.py` → `images/build.py`
   - Simplify: no `vm_username` passthrough, builder user is always `builder`
+  - Accept `--spec` flag to select which image profile to build
   - Keep prerequisite checks, VM lifecycle management, arg parsing
 - [ ] Create image profile specs under `images/specs/`
-  - Each profile is a vars file that the build playbook loads
-  - Profiles compose (e.g., `full.yaml` includes containerd + nvidia + monitoring)
+  - `base.yaml` -- apt packages, go, neovim, fzf, common CLI tools
+  - `containerd.yaml` -- base + nerdctl, uidmap, sysctl, apparmor for rootless containers
+  - `nvidia.yaml` -- base + GPU drivers, container toolkit, gpu exporter
+  - `full.yaml` -- containerd + nvidia + monitoring
+  - Each spec owns its version pins (no shared versions manifest)
 
-### Phase 3: Split containerd tasks
+### Phase 2: Split containerd tasks
 
 - [ ] Extract system-level container prerequisites into `images/tasks/containerd-system.yaml`
   - uidmap package, `/etc/subuid` + `/etc/subgid` templates (parameterized by user)
@@ -186,20 +80,7 @@ loads the full file and references `{{ versions.go.version }}`.
   - `loginctl enable-linger`
 - [ ] System-level tasks run at image build time, user-level tasks run at deploy time
 
-### Phase 4: Read-only root filesystem
-
-- [ ] Create `images/tasks/harden.yaml` (runs last in build playbook)
-  - Configure tmpfs mounts in fstab for `/tmp`, `/var/tmp`, `/run`
-  - Mark root filesystem read-only in fstab (`defaults,ro`)
-  - Ensure `/var/lib` and `/home` are on separate mutable mounts
-  - Set up `tmpfiles.d` entries for volatile paths that services expect
-- [ ] Test with a deployed VM to verify:
-  - System boots cleanly with ro root
-  - Container volumes under `$HOME` are writable
-  - Logs, package state, and other mutable paths work correctly
-  - `apt` operations are blocked (or require remount -- this is intentional)
-
-### Phase 5: Refactor deployment path
+### Phase 3: Refactor deployment path
 
 - [ ] Create `vms/deploy.yaml` for post-boot identity provisioning
   - Cloud-init handles: user creation, hostname, IP, SSH key import
@@ -209,7 +90,7 @@ loads the full file and references `{{ versions.go.version }}`.
   - This is user-scoped, not image-scoped
 - [ ] Retire `custom-base-image.yaml` and its tagged multi-play approach
 
-### Phase 6: Cleanup
+### Phase 4: Cleanup
 
 - [ ] Remove `bootstrap-deployer.yaml` if deployer user is no longer needed
   (deploy.yaml creates the correct user per-VM via cloud-init)
@@ -217,32 +98,25 @@ loads the full file and references `{{ versions.go.version }}`.
 - [ ] Update `requirements.yaml` to declare all used roles (prometheus)
 - [ ] Delete dead code and unused templates
 
-## Current Version Sprawl (for reference)
+## Future Considerations
 
-Tools with versions defined in multiple places (at time of writing):
-
-| Tool                 | install.py | custom-base-image.yaml | common.yaml | set-up.yaml | tasks/nvidia.yaml | bash/installs |
-|----------------------|-----------|------------------------|-------------|-------------|-------------------|---------------|
-| nerdctl              | 2.0.3     | 2.1.3                  | --          | 2.1.3       | --                | --            |
-| go                   | --        | 1.24.2                 | 1.24.2      | --          | --                | 1.19.4        |
-| neovim               | --        | 0.11.3                 | 0.11.3      | --          | --                | 0.10.4        |
-| nvidia_gpu_exporter  | --        | 1.3.2                  | --          | 1.3.2       | 1.3.2             | --            |
-
-`shell/bash/installs` also has stale pins for clusterctl, glow, helm, k9s, kind,
-kubectx, node.js, python, shellcheck, tmux, vivid -- most from a previous k8s era.
+- **Versions consolidation**: If version sprawl across specs becomes a
+  maintenance burden, consolidate pins into a shared `versions.yaml`. Not
+  worth the upfront investment right now.
+- **Read-only root filesystem**: fstab `ro` + mutable bind mounts for `/home`
+  and `/var/lib`. Pairs well with rootless nerdctl (all container state under
+  `$HOME`). dm-verity is a further step for tamper-evident roots.
+- **install.py refactor**: The current `PROGRAMS` dict in `shell/scripts/install.py`
+  works fine for user-level CLI tools. Could be unified with image specs later
+  if the overlap justifies it.
 
 ## Notes
 
 - The Python orchestrator (`build.py`) is the right approach for managing the
   build VM lifecycle. Packer would replace ~100 lines of this script but adds a
   dependency for minimal gain.
-- `versions.yaml` at the repo root is the single source of truth for all binary
-  versions. install.py consumes it for user-level CLI tools, Ansible consumes it
-  for system-level installs. No version is defined in more than one place.
-- The read-only root pairs naturally with rootless nerdctl: all container state
-  lives under `$HOME` on a mutable filesystem, while the OS root is immutable.
-- dm-verity is a future option for tamper-evident roots but significantly more
-  complex. Start with fstab `ro` + mutable bind mounts.
 - Container image versions (compose files under `homelab/services/`) are out of
-  scope for `versions.yaml` -- those are pinned per-service and don't overlap
-  with the CLI/system tool versions.
+  scope -- those are pinned per-service and don't overlap with system tool
+  versions.
+- After base images are stable, the next focus is Ansible-driven VM topologies
+  for testing multi-tier scenarios (web-db-cache, queue systems, etc.).

--- a/homelab/images/build-playbook.yaml
+++ b/homelab/images/build-playbook.yaml
@@ -1,0 +1,137 @@
+---
+# Image Build Playbook
+#
+# Builds a user-agnostic base image from an Ubuntu cloud image.
+# Connects as the cloud-init default user (ubuntu), installs system-level
+# packages from a spec file, cleans up, and converts the disk to a base image.
+#
+# Usage:
+#   ansible-playbook build-playbook.yaml -e "spec=base custom_image_name=my-image"
+#
+# Tags:
+#   setup    -- apt upgrade + package installation
+#   finalize -- cleanup, user deletion, VM shutdown, disk conversion
+
+- name: Build Image
+  hosts: custom-image-builder
+  remote_user: ubuntu
+  become: true
+  vars:
+    ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+  vars_files:
+    - "specs/{{ spec }}.yaml"
+
+  tasks:
+    - name: Wait for system to be ready
+      wait_for_connection:
+        timeout: 300
+      tags: [setup]
+
+    - name: Update and upgrade apt packages
+      apt:
+        update_cache: true
+        upgrade: dist
+      tags: [setup]
+
+    - name: Install packages from spec
+      apt:
+        name: "{{ apt_packages }}"
+        state: present
+      when: apt_packages is defined and apt_packages | length > 0
+      tags: [setup]
+
+    # --- Finalize: clean system artifacts, then delete build user ---
+
+    - name: Clean package cache
+      apt:
+        autoclean: true
+        autoremove: true
+      tags: [finalize]
+
+    - name: Clear bash history
+      file:
+        path: /root/.bash_history
+        state: absent
+      tags: [finalize]
+
+    - name: Clear cloud-init logs and data
+      file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - /var/log/cloud-init.log
+        - /var/log/cloud-init-output.log
+        - /var/lib/cloud/instances
+        - /var/lib/cloud/instance
+      tags: [finalize]
+
+    - name: Clear SSH host keys (regenerated on first boot)
+      shell: rm -f /etc/ssh/ssh_host_*
+      tags: [finalize]
+
+    - name: Clear machine-id (regenerated on first boot)
+      copy:
+        content: ""
+        dest: /etc/machine-id
+      tags: [finalize]
+
+    - name: Vacuum systemd journal
+      command: journalctl --vacuum-time=1s
+      tags: [finalize]
+
+    - name: Clean temporary files and truncate logs
+      shell: |
+        rm -rf /tmp/*
+        rm -rf /var/tmp/*
+        find /var/log -type f -exec truncate -s 0 {} \;
+      tags: [finalize]
+
+    - name: Delete cloud-init default user and sudoers file
+      shell: |
+        userdel -rf ubuntu
+        rm -f /etc/sudoers.d/90-cloud-init-users
+      ignore_unreachable: true
+      tags: [finalize]
+
+- name: Convert VM to Base Image
+  hosts: localhost
+  vars:
+    live_images: /var/lib/libvirt/images
+    base_images: /var/lib/libvirt/images/bases
+  tasks:
+    - name: Shutdown the VM
+      command: virsh shutdown custom-image-builder
+      tags: [finalize]
+
+    - name: Wait for VM to shutdown
+      command: virsh domstate custom-image-builder
+      register: vm_state
+      until: vm_state.stdout.strip() == "shut off"
+      retries: 30
+      delay: 10
+      tags: [finalize]
+
+    - name: Convert VM disk to base image
+      command: >
+        qemu-img convert -f qcow2 -O qcow2 -c
+        {{ live_images }}/custom-image-builder.qcow2
+        {{ base_images }}/{{ custom_image_name }}.qcow2
+      tags: [finalize]
+
+    - name: Display image information
+      command: qemu-img info {{ base_images }}/{{ custom_image_name }}.qcow2
+      register: image_info
+      tags: [finalize]
+
+    - name: Show completion message
+      debug:
+        msg: |
+          Custom base image created successfully!
+
+          Image: {{ base_images }}/{{ custom_image_name }}.qcow2
+          Spec: {{ spec }}
+
+          {{ image_info.stdout }}
+
+          To use this image, set os: {{ custom_image_name }} in inventory.
+      tags: [finalize]

--- a/homelab/images/build.py
+++ b/homelab/images/build.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""
+Custom Base Image Builder
+
+Builds user-agnostic Ubuntu base images. Creates a temporary VM from a cloud
+image, installs system packages defined by a spec file, cleans up, and converts
+the disk to a reusable base image.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+class ImageBuilder:
+    def __init__(self):
+        self.script_dir = Path(__file__).parent.resolve()
+        self.playbook = "build-playbook.yaml"
+
+        # Default configuration
+        self.base_image = "ubuntu-server-24.04"
+        self.custom_name = ""
+        self.spec = "base"
+        self.run_tags = ["setup", "finalize"]
+
+    def parse_arguments(self):
+        parser = argparse.ArgumentParser(
+            description="Build a custom Ubuntu base image from an image spec.",
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            epilog="""
+EXAMPLES:
+    %(prog)s --name base-24.04                          # Base image (default spec)
+    %(prog)s --name base-24.04 --spec containerd        # With container prerequisites
+    %(prog)s --name base-24.04 --spec full              # Everything
+    %(prog)s --name base-24.04 --setup                  # Setup only (for manual intervention)
+    %(prog)s --name base-24.04 --finalize               # Finalize only (after manual changes)
+    %(prog)s -b ubuntu-server-22.04 --name base-22.04   # Ubuntu 22.04
+
+TAG-BASED WORKFLOW:
+    For images requiring manual intervention between setup and finalization:
+    1. Run with --setup to install and configure packages
+    2. Make manual adjustments to the VM as needed
+    3. Run with --finalize to clean up and create the final base image
+
+The resulting image will be saved to:
+    /var/lib/libvirt/images/bases/{NAME}.qcow2
+
+You can then reference it in inventory as:
+    os: {NAME}
+            """,
+        )
+
+        parser.add_argument(
+            "-b",
+            "--base-image",
+            choices=["ubuntu-server-24.04", "ubuntu-server-22.04"],
+            default=self.base_image,
+            help="Base image to use (default: %(default)s)",
+        )
+
+        parser.add_argument(
+            "-o",
+            "--name",
+            required=True,
+            help="Name for the output image (e.g., base-24.04)",
+        )
+
+        parser.add_argument(
+            "-s",
+            "--spec",
+            default=self.spec,
+            help="Image spec to use (default: %(default)s). Loads specs/{SPEC}.yaml",
+        )
+
+        tag_group = parser.add_mutually_exclusive_group()
+        tag_group.add_argument(
+            "--setup",
+            action="store_true",
+            help="Run only setup tasks (install packages)",
+        )
+        tag_group.add_argument(
+            "--finalize",
+            action="store_true",
+            help="Run only finalization tasks (cleanup, convert to base image)",
+        )
+
+        args = parser.parse_args()
+
+        self.base_image = args.base_image
+        self.custom_name = args.name
+        self.spec = args.spec
+
+        if args.setup:
+            self.run_tags = ["setup"]
+        elif args.finalize:
+            self.run_tags = ["finalize"]
+        else:
+            self.run_tags = ["setup", "finalize"]
+
+        return args
+
+    def print_config(self):
+        print("Building custom base image:")
+        print(f"   Base image: {self.base_image}")
+        print(f"   Output name: {self.custom_name}")
+        print(f"   Spec: {self.spec}")
+        print(f"   Tags: {','.join(self.run_tags)}")
+        print()
+
+    def check_prerequisites(self):
+        print("Checking prerequisites...")
+
+        required_commands = ["just", "ansible-playbook", "virsh"]
+        for cmd in required_commands:
+            if subprocess.run(["which", cmd], capture_output=True).returncode != 0:
+                print(f"Error: {cmd} not found.")
+                sys.exit(1)
+
+        ssh_key_path = Path.home() / ".ssh" / "id_ed25519.pub"
+        if not ssh_key_path.exists():
+            print("Error: SSH public key not found at ~/.ssh/id_ed25519.pub")
+            sys.exit(1)
+
+        base_image_path = Path(
+            f"/var/lib/libvirt/images/bases/{self.base_image}.qcow2"
+        )
+        if not base_image_path.exists():
+            print(f"Error: Base image not found: {base_image_path}")
+            print("   Run: ansible-playbook vms/base-images.yaml")
+            sys.exit(1)
+
+        spec_path = self.script_dir / "specs" / f"{self.spec}.yaml"
+        if not spec_path.exists():
+            print(f"Error: Spec file not found: {spec_path}")
+            print(f"   Available specs: {', '.join(p.stem for p in (self.script_dir / 'specs').glob('*.yaml'))}")
+            sys.exit(1)
+
+        print("Prerequisites OK")
+        print()
+
+    def run_command(self, cmd, check=True, cwd=None):
+        result = subprocess.run(
+            cmd, shell=True, cwd=cwd, capture_output=True, text=True
+        )
+        if check and result.returncode != 0:
+            print(f"Command failed: {cmd}")
+            print(f"Error: {result.stderr}")
+            sys.exit(1)
+        return result
+
+    def cleanup_stale_disks(self):
+        """Remove leftover disk files from previous builds.
+
+        The delete playbook skips disk removal if the VM is no longer defined
+        in libvirt, leaving orphaned qcow2/iso files owned by libvirt-qemu
+        that block qemu-img create.
+        """
+        libvirt_images = Path("/var/lib/libvirt/images")
+        stale_files = [
+            libvirt_images / "custom-image-builder.qcow2",
+            libvirt_images / "custom-image-builder-cloud-init.iso",
+        ]
+        for path in stale_files:
+            if path.exists():
+                try:
+                    path.unlink()
+                    print(f"   Removed stale {path.name}")
+                except PermissionError:
+                    print(f"   Cannot remove {path} -- trying with sudo")
+                    subprocess.run(["sudo", "rm", "-f", str(path)], check=True)
+
+    def handle_vm_creation(self):
+        if "setup" in self.run_tags:
+            print("Cleaning up any existing builder VM...")
+            os.chdir(self.script_dir.parent)
+
+            result = subprocess.run(
+                ["just", "delete", "custom-image-builder"],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode == 0:
+                print("   Existing VM cleaned up")
+            else:
+                print("   No existing VM to clean up")
+
+            self.cleanup_stale_disks()
+
+            print("Creating builder VM...")
+
+            cmd = [
+                "ansible-playbook",
+                "vms/create-linux.yaml",
+                "--inventory",
+                str(Path.home() / ".files/homelab/inventory.yaml"),
+                "--vault-password-file",
+                str(Path.home() / ".ansible-password"),
+                "--extra-vars",
+                "target_vms=custom-image-builder",
+            ]
+
+            result = subprocess.run(cmd)
+            if result.returncode != 0:
+                print("Failed to create builder VM")
+                sys.exit(1)
+
+            print("Builder VM created")
+            time.sleep(15)
+
+        elif self.run_tags == ["finalize"]:
+            print("Using existing builder VM for finalization...")
+            os.chdir(self.script_dir.parent)
+
+            result = subprocess.run(
+                ["virsh", "domstate", "custom-image-builder"],
+                capture_output=True,
+                text=True,
+            )
+
+            if result.returncode != 0:
+                print("Error: VM 'custom-image-builder' does not exist. Run setup first:")
+                print(f"   {sys.argv[0]} --name {self.custom_name} --setup")
+                sys.exit(1)
+
+            vm_state = result.stdout.strip()
+            if vm_state != "running":
+                print("Starting existing builder VM...")
+                subprocess.run(
+                    ["virsh", "start", "custom-image-builder"], check=True
+                )
+                time.sleep(15)
+
+    def run_ansible_playbook(self):
+        print("Running build playbook...")
+        os.chdir(self.script_dir)
+
+        cmd = [
+            "ansible-playbook",
+            self.playbook,
+            "-e",
+            f"spec={self.spec}",
+            "-e",
+            f"custom_image_name={self.custom_name}",
+            "--inventory",
+            str(Path.home() / ".files/homelab/inventory.yaml"),
+        ]
+
+        if "setup" in self.run_tags and "finalize" not in self.run_tags:
+            cmd.extend(["--limit", "custom-image-builder"])
+
+        if self.run_tags != ["setup", "finalize"]:
+            cmd.extend(["--tags", ",".join(self.run_tags)])
+
+        print(f"Running: {' '.join(cmd)}")
+        result = subprocess.run(cmd)
+
+        return result.returncode == 0
+
+    def handle_success(self):
+        if "finalize" in self.run_tags:
+            print()
+            print("Build completed successfully!")
+            print("Cleaning up builder VM...")
+            result = subprocess.run(
+                ["just", "delete", "custom-image-builder"], capture_output=True
+            )
+            if result.returncode != 0:
+                print("Warning: Failed to delete builder VM")
+        elif self.run_tags == ["setup"]:
+            print()
+            print("Setup phase completed.")
+            print("VM 'custom-image-builder' is running for manual adjustments:")
+            print("    SSH: ssh ubuntu@10.0.0.10")
+            print("    Console: virsh console custom-image-builder")
+            print()
+            print("After manual changes, finalize:")
+            print(f"   {sys.argv[0]} --name {self.custom_name} --finalize")
+            print()
+            print("Or cleanup: just delete custom-image-builder")
+
+    def handle_failure(self):
+        print()
+        print("Build failed. Check output above.")
+        print("VM left running for investigation:")
+        print("    SSH: ssh ubuntu@10.0.0.10")
+        print("    Console: virsh console custom-image-builder")
+        print("    Cleanup: just delete custom-image-builder")
+
+    def build(self):
+        self.parse_arguments()
+        self.print_config()
+        self.check_prerequisites()
+        self.handle_vm_creation()
+
+        success = self.run_ansible_playbook()
+
+        if success:
+            self.handle_success()
+        else:
+            self.handle_failure()
+            sys.exit(1)
+
+
+def main():
+    builder = ImageBuilder()
+    builder.build()
+
+
+if __name__ == "__main__":
+    main()

--- a/homelab/images/specs/base.yaml
+++ b/homelab/images/specs/base.yaml
@@ -1,0 +1,11 @@
+---
+# Base image spec -- minimal system packages on top of Ubuntu cloud image
+apt_packages:
+  - curl
+  - git
+  - jq
+  - make
+  - tmux
+  - unzip
+  - wget
+  - zsh

--- a/homelab/images/specs/containerd.yaml
+++ b/homelab/images/specs/containerd.yaml
@@ -1,0 +1,13 @@
+---
+# Containerd image spec -- base packages plus container runtime prerequisites
+# Phase 2: will add containerd-system tasks (apparmor, sysctl, subuid/subgid)
+apt_packages:
+  - curl
+  - git
+  - jq
+  - make
+  - tmux
+  - unzip
+  - wget
+  - zsh
+  - uidmap

--- a/homelab/images/specs/full.yaml
+++ b/homelab/images/specs/full.yaml
@@ -1,0 +1,14 @@
+---
+# Full image spec -- all packages (containerd + nvidia + monitoring)
+# Phase 2: will add containerd-system, nvidia, and monitoring tasks
+apt_packages:
+  - curl
+  - git
+  - jq
+  - make
+  - tmux
+  - unzip
+  - wget
+  - zsh
+  - uidmap
+  - ubuntu-drivers-common

--- a/homelab/images/specs/nvidia.yaml
+++ b/homelab/images/specs/nvidia.yaml
@@ -1,0 +1,13 @@
+---
+# NVIDIA image spec -- base packages plus GPU driver prerequisites
+# Phase 2: will add nvidia driver installation tasks
+apt_packages:
+  - curl
+  - git
+  - jq
+  - make
+  - tmux
+  - unzip
+  - wget
+  - zsh
+  - ubuntu-drivers-common

--- a/homelab/inventory.yaml
+++ b/homelab/inventory.yaml
@@ -51,7 +51,7 @@ all:
         custom-image-builder:
           hosts:
             custom-image-builder:
-              ansible_host: 10.0.0.7
+              ansible_host: 10.0.0.10
               os: "ubuntu-server-24.04"
               vcpus: 4
               memory: 8

--- a/homelab/sandboxes/DESIGN.md
+++ b/homelab/sandboxes/DESIGN.md
@@ -1,0 +1,255 @@
+# Sandbox Orchestrator
+
+A CLI tool that creates ephemeral multi-VM environments from declarative
+topology definitions, provisions them with containers, validates with tests,
+and tears everything down.
+
+## Scope
+
+Scenario VMs only. Long-lived VMs (devbox, staging) are managed separately.
+
+## Domain
+
+The hypervisor is a single bare-metal machine running KVM/libvirt. VMs boot
+from pre-built qcow2 base images (built by the existing `images/build.py`
+pipeline). Cloud-init handles first-boot identity (user, network, SSH keys).
+Containers run rootless via nerdctl.
+
+## Core Operations
+
+```
+sandbox up   <topology>       # create VMs, provision, deploy containers
+sandbox test <topology>       # run test suite against running topology
+sandbox down <topology>       # destroy VMs, reclaim disks
+sandbox list                  # show running sandboxes
+sandbox ssh  <topology> <node># shell into a specific node
+```
+
+## Data Model
+
+### Topology
+
+Defines a set of nodes, their resources, and what containers they run.
+
+```yaml
+# topologies/web-db.yaml
+name: web-db
+description: Nginx reverse proxy + Postgres
+
+defaults:
+  image: base-24.04
+  disk: 25G
+  user: deployer
+
+nodes:
+  web:
+    ip: 10.0.0.40
+    vcpus: 2
+    memory: 4
+    containers:
+      - nginx
+    expose:
+      - "80:80"
+
+  db:
+    ip: 10.0.0.41
+    vcpus: 2
+    memory: 4
+    containers:
+      - postgres
+    expose:
+      - "5432:5432"
+
+test: web-db
+```
+
+```yaml
+# topologies/poller-queue-worker-db.yaml
+name: poller-queue-worker-db
+description: >
+  Async processing: poller feeds work into RabbitMQ, workers consume
+  and persist results to Postgres.
+
+defaults:
+  image: base-24.04
+  disk: 25G
+  user: deployer
+
+nodes:
+  poller:
+    ip: 10.0.0.46
+    vcpus: 1
+    memory: 2
+    containers:
+      - nginx
+    expose:
+      - "80:80"
+
+  queue:
+    ip: 10.0.0.47
+    vcpus: 2
+    memory: 4
+    containers:
+      - rabbitmq
+    expose:
+      - "5672:5672"
+      - "15672:15672"
+
+  worker:
+    ip: 10.0.0.48
+    vcpus: 2
+    memory: 4
+
+  db:
+    ip: 10.0.0.49
+    vcpus: 2
+    memory: 4
+    containers:
+      - postgres
+    expose:
+      - "5432:5432"
+
+test: poller-queue-worker-db
+```
+
+### Container Definitions
+
+Nerdctl compose files, one per service. The orchestrator copies the compose
+file to the node and runs `nerdctl compose up -d`.
+
+```
+containers/
+  postgres/compose.yaml
+  redis/compose.yaml
+  rabbitmq/compose.yaml
+  nginx/compose.yaml
+```
+
+### Test Suites
+
+k6 test scenarios, one per topology. The orchestrator injects node IPs as
+environment variables.
+
+```
+tests/
+  scenarios/
+    web-db.ts
+    poller-queue-worker-db.ts
+```
+
+## Lifecycle: `sandbox up`
+
+1. **Parse topology** -- read YAML, merge defaults into each node
+2. **Create disks** -- for each node, `qemu-img create` backed by base image
+3. **Generate cloud-init** -- render userdata (user, SSH keys), network-config
+   (static IP), metadata (hostname). Build ISO with `cloud-localds`.
+4. **Define VMs** -- render libvirt domain XML, `virsh define`, `virsh start`
+5. **Wait for SSH** -- poll each node until SSH responds
+6. **Provision containers** -- for each node with containers defined:
+   - Ensure rootless container prerequisites (uidmap, subuid/subgid, apparmor,
+     sysctl, nerdctl). This can be baked into the base image or applied here.
+   - Copy compose file to node
+   - `nerdctl compose up -d`
+   - Wait for health checks to pass
+7. **Report** -- print node IPs, exposed ports, SSH commands
+
+## Lifecycle: `sandbox test`
+
+1. Resolve node IPs from running sandbox state
+2. Run k6 with topology-specific scenario, passing IPs as env vars
+3. Report results
+
+## Lifecycle: `sandbox down`
+
+1. For each node: `virsh destroy`, `virsh undefine`
+2. Remove disk images and cloud-init ISOs
+3. Clean up any sandbox state
+
+## State
+
+Running sandbox state needs to be tracked so `test` and `down` know what
+exists. Options:
+
+- **Derive from libvirt** -- naming convention `sandbox-{topology}-{node}`
+  lets you query `virsh list` and reconstruct state. No state file needed.
+- **State file** -- `~/.sandbox/{topology}.json` with node names, IPs,
+  status. More explicit but needs cleanup.
+
+Deriving from libvirt is simpler and avoids stale state.
+
+## VM Naming and Networking
+
+- VM names: `sandbox-{topology}-{node}` (e.g., `sandbox-web-db-web`)
+- IP range: `10.0.0.40-59` (reserved for sandboxes)
+- Each topology's nodes get sequential IPs from the topology definition
+
+## Templates
+
+The tool needs to generate:
+
+- **Cloud-init userdata** -- user, groups, sudo, SSH key import, password
+- **Cloud-init network-config** -- static IP, gateway, DNS
+- **Cloud-init metadata** -- instance-id, hostname
+- **Libvirt domain XML** -- CPU, memory, disk path, cloud-init ISO, network
+
+These are small enough to be string templates embedded in the tool, or
+external template files in a `templates/` directory.
+
+## Container Provisioning
+
+The base image may or may not have nerdctl/containerd ready. Two options:
+
+- **Fat image**: `images/specs/containerd.yaml` bakes in all container
+  prerequisites. Sandbox nodes just copy compose files and `nerdctl compose up`.
+- **Provision at boot**: The orchestrator installs nerdctl + prerequisites
+  over SSH before deploying containers.
+
+Fat image is faster for scenarios (less per-VM setup time). Provision at boot
+is more flexible but slower. Start with fat image -- build a `sandbox-base`
+image spec with containerd baked in.
+
+## Directory Structure
+
+```
+homelab/sandboxes/
+  DESIGN.md                       # this file
+  topologies/
+    web-db.yaml
+    web-cache-db.yaml
+    poller-queue-worker-db.yaml
+  containers/
+    postgres/compose.yaml
+    redis/compose.yaml
+    rabbitmq/compose.yaml
+    nginx/compose.yaml
+  templates/                      # cloud-init + libvirt templates
+    userdata.yaml
+    network-config.yaml
+    metadata.yaml
+    domain.xml
+  tests/
+    package.json
+    scenarios/
+      web-db.ts
+      web-cache-db.ts
+      poller-queue-worker-db.ts
+```
+
+The CLI tool itself lives outside this directory (its own repo or a
+subdirectory with its own build).
+
+## Open Questions
+
+- **Container readiness**: How to detect that a containerized service is
+  healthy? Poll a TCP port? nerdctl inspect health status? Topology-defined
+  health check commands?
+- **Inter-node discovery**: Containers on one node need to reach services on
+  another (e.g., web → db). Inject peer IPs via environment variables in the
+  compose file? Template the compose files with node IPs?
+- **Secrets**: Postgres passwords, RabbitMQ credentials. Generate per-sandbox
+  and inject via compose env vars? Or use static defaults for throwaway
+  scenarios?
+- **Log collection**: Should sandbox nodes ship logs to the monitoring stack,
+  or are scenarios too ephemeral for that?
+- **Parallel provisioning**: Nodes are independent -- create and provision
+  them concurrently for faster `up`.

--- a/homelab/vms/bootstrap-deployer.yaml
+++ b/homelab/vms/bootstrap-deployer.yaml
@@ -30,15 +30,6 @@
         create: true
         validate: "visudo -cf %s"
 
-    - name: Allow deployer user to sudo without password
-      lineinfile:
-        path: /etc/sudoers.d/deployer
-        line: "deployer ALL=(ALL) NOPASSWD:ALL"
-        state: present
-        mode: "0440"
-        create: true
-        validate: "visudo -cf %s"
-
     - name: Set Hostname
       hostname:
         name: "{{ ansible_host }}"

--- a/homelab/vms/create-linux.yaml
+++ b/homelab/vms/create-linux.yaml
@@ -35,7 +35,7 @@
               'gpu_domain': hostvars[item]['gpu_domain'] | default(''),
               'gpu_bus': hostvars[item]['gpu_bus'] | default(''),
               'gpu_slot': hostvars[item]['gpu_slot'] | default(''),
-              'username': hostvars[item]['username'] | default('ubuntu')
+              'username': hostvars[item]['username'] | default(vm_username | default('ubuntu'))
             }]
           }}
       loop: "{{ groups['vms'] }}"

--- a/homelab/vms/custom-base-image.yaml
+++ b/homelab/vms/custom-base-image.yaml
@@ -112,6 +112,24 @@
   vars:
     ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
   tasks:
+    - name: Remove cloud-init default user
+      user:
+        name: "{{ default_os_username | default('ubuntu') }}"
+        state: absent
+        remove: true
+      become: true
+      when: (default_os_username | default('ubuntu')) != target_username
+      tags:
+        - finalize
+
+    - name: Remove cloud-init default user sudoers file
+      file:
+        path: "/etc/sudoers.d/90-cloud-init-users"
+        state: absent
+      become: true
+      tags:
+        - finalize
+
     - name: Clean up package cache
       apt:
         autoclean: yes
@@ -145,8 +163,14 @@
         - finalize
 
     - name: Clear SSH host keys (will be regenerated on first boot)
+      shell: rm -f /etc/ssh/ssh_host_*
+      become: true
+      tags:
+        - finalize
+
+    - name: Clear target user SSH authorized keys (will be re-imported on deployment)
       file:
-        path: "/etc/ssh/ssh_host_*"
+        path: "/home/{{ target_username | default('steven') }}/.ssh/authorized_keys"
         state: absent
       become: true
       tags:

--- a/homelab/vms/example-scenario.yaml
+++ b/homelab/vms/example-scenario.yaml
@@ -1,0 +1,48 @@
+name: poller-queue-worker-db
+description: >
+  Async processing architecture: A poller feeds work into a RabbitMQ message
+  queue, workers consume and process jobs, results are persisted to Postgres.
+  Tests backpressure handling, queue depth, and worker throughput under load.
+
+defaults:
+  os: sf1tzp-24.04
+  disk_size: 25G
+  username: deployer
+
+nodes:
+  poller:
+    ip: 10.0.0.46
+    vcpus: 1
+    memory: 2
+    containers:
+      - nginx
+    expose:
+      - "80:80"
+
+  queue:
+    ip: 10.0.0.47
+    vcpus: 2
+    memory: 4
+    containers:
+      - rabbitmq
+    expose:
+      - "5672:5672"
+      - "15672:15672"
+
+  worker:
+    ip: 10.0.0.48
+    vcpus: 2
+    memory: 4
+    containers: []
+    expose: []
+
+  db:
+    ip: 10.0.0.49
+    vcpus: 2
+    memory: 4
+    containers:
+      - postgres
+    expose:
+      - "5432:5432"
+
+test: poller-queue-worker-db

--- a/homelab/vms/scenarios.md
+++ b/homelab/vms/scenarios.md
@@ -1,0 +1,44 @@
+Yes -- I've read through everything I need. I have a clear picture of the existing infrastructure now. Let me lay out the plan before I start writing code.
+
+## Design
+
+**Core idea:** A `homelab/sandboxes/` directory that defines architecture patterns as YAML topologies. A single Ansible playbook reads a topology, creates the VMs (reusing your existing cloud-init/libvirt patterns), deploys containers via nerdctl compose over SSH, and k6 tests validate the deployment. Teardown is one command.
+
+**Key design decisions:**
+- **Sandbox VMs use the `10.0.0.40-59` range** -- clear of your existing allocations
+- **VM naming convention:** `sandbox-{arch}-{role}` (e.g., `sandbox-web-db-web`, `sandbox-web-db-db`)
+- **Base image:** `sf1tzp-24.04` -- your custom image already has tooling, and VMs get containerd during provisioning
+- **Self-contained inventory** -- sandbox playbooks generate their own inventory from the architecture file, no pollution of your main `inventory.yaml`
+- **Container compositions per role** -- postgres, redis, rabbitmq, nginx each get a nerdctl compose file
+- **k6 scenarios per architecture** -- parameterized with sandbox VM IPs via env vars
+
+**Architecture patterns to define:**
+1. `web-db` -- Nginx reverse proxy + Postgres
+2. `web-cache-db` -- Nginx + Redis + Postgres
+3. `poller-queue-worker-db` -- Poller service + RabbitMQ + Worker + Postgres
+
+**File structure:**
+```
+homelab/sandboxes/
+├── justfile                              # deploy, provision, test, teardown
+├── deploy.yaml                           # Create VMs from architecture def
+├── provision.yaml                        # SSH in, deploy containers per role
+├── teardown.yaml                         # Destroy sandbox VMs + cleanup
+├── architectures/
+│   ├── web-db.yaml
+│   ├── web-cache-db.yaml
+│   └── poller-queue-worker-db.yaml
+├── containers/
+│   ├── postgres/compose.yaml
+│   ├── redis/compose.yaml
+│   ├── rabbitmq/compose.yaml
+│   └── nginx/compose.yaml
+└── tests/
+    ├── package.json
+    ├── helpers.ts                        # Shared k6 utilities
+    └── scenarios/
+        ├── web-db.ts
+        ├── web-cache-db.ts
+        └── poller-queue-worker-db.ts
+```
+

--- a/homelab/vms/templates/userdata.yaml.j2
+++ b/homelab/vms/templates/userdata.yaml.j2
@@ -2,7 +2,7 @@
 hostname: {{ item.hostname }}
 
 users:
-  - name: {{ item.username | default("steven") }}
+  - name: {{ item.username }}
     groups: sudo
     sudo: ALL=(ALL) NOPASSWD:ALL
     shell: /bin/bash
@@ -11,5 +11,5 @@ users:
 
 chpasswd:
   list: |
-    {{ item.username | default("steven") }}:{{ user_password | mandatory }}
+    {{ item.username }}:{{ user_password | mandatory }}
   expire: false


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive redesign plan for the custom VM image build pipeline and makes immediate fixes to cloud-init user handling in the deployment flow.

The changes address two key issues:
1. **Image build complexity**: Current playbooks conflate image building with VM deployment, creating temporary users that should be cleaned up but sometimes persist with sudo access
2. **Cloud-init user management**: Default OS users (e.g., `ubuntu`) created by cloud-init are not being properly removed from final images

## Key Changes

### New: Image Build Redesign Plan (`homelab/images/PLAN.md`)

A detailed 6-phase redesign plan that establishes clear separation of concerns:

- **Phase 1**: Consolidate all tool versions into a single `versions.yaml` manifest at repo root, consumed by both `install.py` and Ansible playbooks
- **Phase 2**: Create dedicated `images/build-playbook.yaml` with a single throwaway `builder` user, eliminating finalize gymnastics
- **Phase 3**: Split containerd setup into system-level (image build) and per-user (deployment) tasks
- **Phase 4**: Implement read-only root filesystem with tmpfs mounts for volatile paths
- **Phase 5**: Refactor deployment into `vms/deploy.yaml` for post-boot identity provisioning
- **Phase 6**: Clean up dead code and consolidate inventory conventions

**Design principle**: Images are user-agnostic system artifacts; users, SSH keys, hostnames, and IPs are deployment concerns applied after boot.

### Fixed: Cloud-init User Cleanup

- **`custom-base-image.yaml`**: Add tasks to remove the default cloud-init user (`ubuntu`) and its sudoers file during image finalization
- **`custom-base-image.yaml`**: Clear target user's SSH authorized_keys (will be re-imported during deployment)
- **`bootstrap-deployer.yaml`**: Remove passwordless sudo grant for deployer user (security hardening)
- **`create-linux.yaml`**: Fix username default to use `vm_username` variable with fallback to `ubuntu`
- **`userdata.yaml.j2`**: Remove default username fallback; require explicit username from inventory

## Implementation Notes

- The plan documents current version sprawl across 6 different files (nerdctl, go, neovim, nvidia_gpu_exporter defined in multiple places)
- `versions.yaml` format supports three installation patterns: binary in subdirectory, binary at archive root, and whole-tree extraction
- Read-only root filesystem pairs naturally with rootless nerdctl (all container state under `$HOME` on mutable filesystem)
- Python orchestrator (`build.py`) is preferred over Packer for minimal dependency overhead
- Cloud-init user removal ensures no unintended users with sudo access persist in base images

https://claude.ai/code/session_015MdD2boinxxvPts5CBCHEp