### PR TITLE
Add Windows VM (win11) boot service & firewall config

### DIFF
--- a/windows/README.md
+++ b/windows/README.md
@@ -1,0 +1,74 @@
+# Windows VM config — `win11` (10.0.0.99)
+
+Boot-time service and firewall setup for the Windows inference/monitoring VM. All
+services start **at boot without requiring a login** and bind to all interfaces so
+they are reachable on the homelab LAN.
+
+## Services
+
+| Service | Port | Mechanism | Run as | Scraped by |
+|---|---|---|---|---|
+| LM Studio API (OpenAI-compatible) | 11434 | Scheduled task, `AtStartup` | `win11\sfitz` (S4U, no stored password) | clients |
+| Prometheus `windows_exporter` (node metrics) | 9182 | Windows service (MSI) | LocalSystem | Prometheus job `windows_exporter` |
+| Prometheus `nvidia_gpu_exporter` (RTX 3060) | 9835 | Scheduled task, `AtStartup` | `NT AUTHORITY\SYSTEM` | Prometheus job `nvidia_gpu_exporter` |
+
+The matching scrape targets already exist in
+`homelab/services/monitoring/config/prometheus.yaml` (instance `win11`).
+
+## Why scheduled tasks for two of these?
+
+LM Studio's `lms` CLI and `nvidia_gpu_exporter` are plain console programs that don't
+implement the Windows service control protocol, so `sc.exe`/SCM can't manage them
+directly. An `AtStartup` scheduled task gives the same "start at boot, no login"
+behavior. `windows_exporter` ships a proper MSI, so it's a real service.
+
+- LM Studio runs under an **S4U** principal: it needs the `sfitz` user profile
+  (scoop install + model paths) but should run without anyone logged in, and S4U
+  achieves that without storing a password.
+- `nvidia_gpu_exporter` needs no user profile (it just calls `nvidia-smi` on the
+  system PATH), so it runs as **SYSTEM**.
+
+## Setup (run from an elevated PowerShell)
+
+```powershell
+# Services
+.\services\lmstudio-server.ps1
+.\services\windows-exporter.ps1
+.\services\nvidia-gpu-exporter.ps1
+
+# Firewall (opens 11434, 9182, 9835)
+.\firewall\firewall-rules.ps1
+```
+
+Each script is parameterized (version, port, install dir, …) with sensible defaults
+and is idempotent — re-running re-registers/repairs.
+
+## Firewall / network profile note
+
+This VM's NIC is classified **Public**, so the firewall rules are scoped to `Any`.
+If you switch the connection to Private:
+
+```powershell
+Set-NetConnectionProfile -InterfaceAlias "Ethernet Instance 0" -NetworkCategory Private
+.\firewall\firewall-rules.ps1 -FirewallProfile Private   # optional: tighten scope
+```
+
+> These are open, unauthenticated endpoints. Keep them on the trusted homelab LAN;
+> do not expose them to the public internet without auth / a reverse proxy.
+
+## Verify
+
+```powershell
+Invoke-RestMethod http://localhost:9182/metrics | Select-Object -First 5
+Invoke-RestMethod http://localhost:9835/metrics | Select-Object -First 5
+(Invoke-WebRequest http://localhost:11434/v1/models).StatusCode
+```
+
+## Manage
+
+```powershell
+Get-ScheduledTask 'LM Studio API Server','NVIDIA GPU Exporter'
+Get-Service windows_exporter
+# Remove:
+Unregister-ScheduledTask -TaskName 'NVIDIA GPU Exporter' -Confirm:$false
+```

--- a/windows/firewall/firewall-rules.ps1
+++ b/windows/firewall/firewall-rules.ps1
@@ -1,0 +1,30 @@
+#requires -RunAsAdministrator
+<#
+.SYNOPSIS
+    Inbound Windows Firewall rules for the services this VM exposes to the homelab LAN.
+.DESCRIPTION
+    Opens the TCP ports used by the LM Studio API and the Prometheus exporters.
+    Scoped to 'Any' profile by default because this VM's NIC is classified Public;
+    a Private-only rule would not apply. Pass -FirewallProfile Private if you have
+    set the connection to Private (Set-NetConnectionProfile ... -NetworkCategory Private).
+.NOTES
+    Run from an elevated PowerShell. Idempotent (recreates the named rules).
+#>
+param(
+    [ValidateSet('Any', 'Private', 'Domain', 'Public')]
+    [string]$FirewallProfile = 'Any'
+)
+$ErrorActionPreference = 'Stop'
+
+$rules = @(
+    @{ Name = 'LM Studio API Server';           Port = 11434 },
+    @{ Name = 'Prometheus windows_exporter';    Port = 9182  },
+    @{ Name = 'Prometheus nvidia_gpu_exporter'; Port = 9835  }
+)
+
+foreach ($r in $rules) {
+    Get-NetFirewallRule -DisplayName $r.Name -ErrorAction SilentlyContinue | Remove-NetFirewallRule
+    New-NetFirewallRule -DisplayName $r.Name -Direction Inbound -Protocol TCP `
+        -LocalPort $r.Port -Action Allow -Profile $FirewallProfile | Out-Null
+    Write-Host "Allowed inbound TCP $($r.Port) [$FirewallProfile] - $($r.Name)"
+}

--- a/windows/services/lmstudio-server.ps1
+++ b/windows/services/lmstudio-server.ps1
@@ -1,0 +1,35 @@
+#requires -RunAsAdministrator
+<#
+.SYNOPSIS
+    Register the LM Studio headless API server to start at boot (no login required).
+.DESCRIPTION
+    Creates a scheduled task that runs `lms server start` at system startup using an
+    S4U principal, so it runs whether or not a user is logged on - without storing a
+    password. Binds to 0.0.0.0 so the OpenAI-compatible API is reachable on the LAN.
+
+    Host: win11 (10.0.0.99). Consumed by the homelab Prometheus/clients.
+.NOTES
+    Run from an elevated PowerShell.  Idempotent (-Force re-registers).
+#>
+param(
+    [string]$LmsPath  = "$env:USERPROFILE\scoop\shims\lms.exe",
+    [string]$RunAsUser = "$env:USERDOMAIN\$env:USERNAME",
+    [int]   $Port     = 11434,
+    [string]$Bind     = '0.0.0.0',
+    [string]$TaskName = 'LM Studio API Server'
+)
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $LmsPath)) { throw "lms not found at $LmsPath (install LM Studio / scoop)" }
+
+$action    = New-ScheduledTaskAction -Execute $LmsPath -Argument "server start --bind $Bind --port $Port"
+$trigger   = New-ScheduledTaskTrigger -AtStartup
+$principal = New-ScheduledTaskPrincipal -UserId $RunAsUser -LogonType S4U -RunLevel Limited
+$settings  = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
+                -StartWhenAvailable -ExecutionTimeLimit ([TimeSpan]::Zero) `
+                -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1)
+
+Register-ScheduledTask -TaskName $TaskName -Action $action -Trigger $trigger -Principal $principal `
+    -Settings $settings -Description 'Starts LM Studio headless API server at VM boot (no login required).' -Force | Out-Null
+
+Write-Host "Registered '$TaskName' -> $LmsPath server start --bind $Bind --port $Port (runs as $RunAsUser, S4U, at startup)"

--- a/windows/services/nvidia-gpu-exporter.ps1
+++ b/windows/services/nvidia-gpu-exporter.ps1
@@ -1,0 +1,48 @@
+#requires -RunAsAdministrator
+<#
+.SYNOPSIS
+    Install utkuozdemir/nvidia_gpu_exporter and run it at boot.
+.DESCRIPTION
+    Downloads the Windows binary, extracts it to Program Files, and registers a
+    scheduled task that runs it at system startup as NT AUTHORITY\SYSTEM (no login
+    required). A scheduled task is used rather than sc.exe because the exporter is a
+    plain console binary and does not implement the Windows service control protocol.
+    It shells out to nvidia-smi (on the system PATH) and listens on :9835.
+
+    Host: win11 (10.0.0.99). Scraped by homelab Prometheus job 'nvidia_gpu_exporter'.
+.NOTES
+    Run from an elevated PowerShell. Idempotent (-Force re-registers).
+#>
+param(
+    [string]$Version    = '1.4.1',
+    [int]   $Port       = 9835,
+    [string]$InstallDir = 'C:\Program Files\nvidia_gpu_exporter',
+    [string]$TaskName   = 'NVIDIA GPU Exporter'
+)
+$ErrorActionPreference = 'Stop'
+
+$zip = "nvidia_gpu_exporter_${Version}_windows_x86_64.zip"
+$url = "https://github.com/utkuozdemir/nvidia_gpu_exporter/releases/download/v$Version/$zip"
+$tmp = Join-Path $env:TEMP $zip
+
+Write-Host "Downloading $url"
+Invoke-WebRequest -Uri $url -OutFile $tmp
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+Expand-Archive -Path $tmp -DestinationPath $InstallDir -Force
+Remove-Item $tmp -Force
+
+$exe = Join-Path $InstallDir 'nvidia_gpu_exporter.exe'
+if (-not (Test-Path $exe)) { throw "exe not found after extract: $exe" }
+
+$action    = New-ScheduledTaskAction -Execute $exe -Argument "--web.listen-address=:$Port"
+$trigger   = New-ScheduledTaskTrigger -AtStartup
+$principal = New-ScheduledTaskPrincipal -UserId 'NT AUTHORITY\SYSTEM' -LogonType ServiceAccount -RunLevel Highest
+$settings  = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
+                -StartWhenAvailable -ExecutionTimeLimit ([TimeSpan]::Zero) `
+                -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1)
+
+Register-ScheduledTask -TaskName $TaskName -Action $action -Trigger $trigger -Principal $principal `
+    -Settings $settings -Description "Prometheus nvidia_gpu_exporter on :$Port (boot, no login)." -Force | Out-Null
+Start-ScheduledTask -TaskName $TaskName
+
+Write-Host "Installed nvidia_gpu_exporter $Version -> task '$TaskName' on :$Port"

--- a/windows/services/windows-exporter.ps1
+++ b/windows/services/windows-exporter.ps1
@@ -1,0 +1,37 @@
+#requires -RunAsAdministrator
+<#
+.SYNOPSIS
+    Install prometheus-community/windows_exporter as an auto-start Windows service.
+.DESCRIPTION
+    Downloads the official MSI and installs it. The MSI registers a LocalSystem
+    service ('windows_exporter') set to Automatic start, listening on :9182 and
+    bound to all interfaces - the Windows equivalent of node_exporter.
+
+    Host: win11 (10.0.0.99). Scraped by homelab Prometheus job 'windows_exporter'.
+.NOTES
+    Run from an elevated PowerShell. Re-running upgrades/repairs the install.
+#>
+param(
+    [string]$Version    = '0.31.7',
+    [int]   $Port       = 9182,
+    [string]$Collectors = ''   # empty => MSI default collector set
+)
+$ErrorActionPreference = 'Stop'
+
+$msi  = "windows_exporter-$Version-amd64.msi"
+$url  = "https://github.com/prometheus-community/windows_exporter/releases/download/v$Version/$msi"
+$dest = Join-Path $env:TEMP $msi
+
+Write-Host "Downloading $url"
+Invoke-WebRequest -Uri $url -OutFile $dest
+
+$msiArgs = "/i `"$dest`" /qn LISTEN_PORT=$Port"
+if ($Collectors) { $msiArgs += " ENABLED_COLLECTORS=$Collectors" }
+
+Write-Host "Installing windows_exporter $Version on :$Port"
+$p = Start-Process msiexec.exe -Wait -PassThru -ArgumentList $msiArgs
+if ($p.ExitCode -ne 0) { throw "msiexec exited with code $($p.ExitCode)" }
+Remove-Item $dest -Force
+
+Start-Sleep -Seconds 2
+Get-Service windows_exporter | Format-List Name, Status, StartType


### PR DESCRIPTION
Boot-time, no-login setup for the win11 (10.0.0.99) inference/monitoring VM:
- lmstudio-server.ps1: LM Studio API on :11434 via S4U scheduled task
- windows-exporter.ps1: prometheus windows_exporter service on :9182
- nvidia-gpu-exporter.ps1: nvidia_gpu_exporter on :9835 via SYSTEM task
- firewall-rules.ps1: inbound rules for 11434/9182/9835 (Any profile)

Scrape targets for these already exist in homelab prometheus.yaml (instance win11).